### PR TITLE
Add color theme configuration to ~/.gpulse.json

### DIFF
--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -1,0 +1,67 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { loadConfig, saveConfig, GpulseConfig } from '../lib/config.js';
+
+export const configCommand = new Command('config')
+  .description('Get or set configuration values')
+  .argument('[key]', 'Configuration key (e.g., theme, defaultUser)')
+  .argument('[value]', 'Value to set (omit to get current value)')
+  .option('--list', 'List all configuration')
+  .action(async (key?: string, value?: string, options?: { list?: boolean }) => {
+    const config = loadConfig();
+
+    // List all config
+    if (options?.list || (!key && !value)) {
+      console.log('');
+      console.log(chalk.bold('  Current Configuration'));
+      console.log('');
+      if (Object.keys(config).length === 0) {
+        console.log(chalk.gray('    No configuration set'));
+      } else {
+        console.log(chalk.gray('    ' + JSON.stringify(config, null, 2).replace(/\n/g, '\n    ')));
+      }
+      console.log('');
+      console.log(chalk.cyan.bold('  Available Theme Presets'));
+      console.log(chalk.gray('    default, minimal, dracula, monokai, solarized'));
+      console.log('');
+      console.log(chalk.cyan.bold('  Examples'));
+      console.log(chalk.gray('    gpulse config theme dracula'));
+      console.log(chalk.gray('    gpulse config defaultUser octocat'));
+      console.log('');
+      return;
+    }
+
+    // Get value
+    if (key && !value) {
+      const val = (config as any)[key];
+      if (val === undefined) {
+        console.log(chalk.yellow(`  Key "${key}" not set`));
+      } else {
+        console.log('');
+        console.log(chalk.bold(`  ${key}:`));
+        console.log(chalk.gray('    ' + JSON.stringify(val, null, 2).replace(/\n/g, '\n    ')));
+        console.log('');
+      }
+      return;
+    }
+
+    // Set value
+    if (key && value) {
+      // Parse JSON if it looks like JSON
+      let parsedValue: any = value;
+      if (value.startsWith('{') || value.startsWith('[')) {
+        try {
+          parsedValue = JSON.parse(value);
+        } catch {
+          console.log(chalk.red('  Invalid JSON value'));
+          process.exit(1);
+        }
+      }
+
+      (config as any)[key] = parsedValue;
+      saveConfig(config);
+      console.log('');
+      console.log(chalk.green(`  ✓ Set ${key} = ${JSON.stringify(parsedValue)}`));
+      console.log('');
+    }
+  });

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { changelogCommand } from './commands/changelog.js';
 import { healthCommand } from './commands/health.js';
 import { reviewCommand } from './commands/review.js';
 import { digestCommand } from './commands/digest.js';
+import { configCommand } from './commands/config.js';
 
 const program = new Command();
 
@@ -21,5 +22,6 @@ program.addCommand(changelogCommand);
 program.addCommand(healthCommand);
 program.addCommand(reviewCommand);
 program.addCommand(digestCommand);
+program.addCommand(configCommand);
 
 program.parse();

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -4,11 +4,65 @@ import { homedir } from 'os';
 
 const CONFIG_PATH = join(homedir(), '.gpulse.json');
 
+export interface ThemeColors {
+  header?: string;
+  subheader?: string;
+  success?: string;
+  warning?: string;
+  error?: string;
+  muted?: string;
+}
+
+export type ThemePreset = 'default' | 'minimal' | 'dracula' | 'monokai' | 'solarized';
+
 export interface GpulseConfig {
   defaultUser?: string;
   defaultOrg?: string;
-  theme?: 'default' | 'minimal';
+  theme?: ThemePreset | ThemeColors;
 }
+
+const THEME_PRESETS: Record<ThemePreset, ThemeColors> = {
+  default: {
+    header: '#FFFFFF',
+    subheader: '#00FFFF',
+    success: '#00FF00',
+    warning: '#FFFF00',
+    error: '#FF0000',
+    muted: '#808080',
+  },
+  minimal: {
+    header: '#FFFFFF',
+    subheader: '#CCCCCC',
+    success: '#AAAAAA',
+    warning: '#999999',
+    error: '#888888',
+    muted: '#666666',
+  },
+  dracula: {
+    header: '#F8F8F2',
+    subheader: '#8BE9FD',
+    success: '#50FA7B',
+    warning: '#F1FA8C',
+    error: '#FF5555',
+    muted: '#6272A4',
+  },
+  monokai: {
+    header: '#F8F8F2',
+    subheader: '#66D9EF',
+    success: '#A6E22E',
+    warning: '#E6DB74',
+    error: '#F92672',
+    muted: '#75715E',
+  },
+  solarized: {
+    header: '#FDF6E3',
+    subheader: '#268BD2',
+    success: '#859900',
+    warning: '#B58900',
+    error: '#DC322F',
+    muted: '#93A1A1',
+  },
+};
 
 export function loadConfig(): GpulseConfig {
   if (!existsSync(CONFIG_PATH)) return {};
@@ -21,4 +75,18 @@ export function loadConfig(): GpulseConfig {
 
 export function saveConfig(config: GpulseConfig): void {
   writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+export function getThemeColors(): ThemeColors {
+  const config = loadConfig();
+  
+  if (!config.theme) {
+    return THEME_PRESETS.default;
+  }
+  
+  if (typeof config.theme === 'string') {
+    return THEME_PRESETS[config.theme] || THEME_PRESETS.default;
+  }
+  
+  return { ...THEME_PRESETS.default, ...config.theme };
 }

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,11 +1,14 @@
 import chalk from 'chalk';
+import { getThemeColors } from './config.js';
+
+const theme = getThemeColors();
 
 export function header(text: string): string {
-  return chalk.bold(text);
+  return chalk.hex(theme.header || '#FFFFFF').bold(text);
 }
 
 export function subheader(text: string): string {
-  return chalk.cyan.bold(`  ${text}`);
+  return chalk.hex(theme.subheader || '#00FFFF').bold(`  ${text}`);
 }
 
 export function item(text: string): string {
@@ -13,18 +16,18 @@ export function item(text: string): string {
 }
 
 export function dimItem(label: string, value: string): string {
-  return `    ${chalk.gray(label)} ${value}`;
+  return `    ${chalk.hex(theme.muted || '#808080')(label)} ${value}`;
 }
 
 export function separator(): string {
-  return chalk.gray('  ' + '─'.repeat(40));
+  return chalk.hex(theme.muted || '#808080')('  ' + '─'.repeat(40));
 }
 
 export function scoreColor(score: number): typeof chalk {
-  if (score >= 90) return chalk.green;
-  if (score >= 70) return chalk.yellow;
+  if (score >= 90) return chalk.hex(theme.success || '#00FF00');
+  if (score >= 70) return chalk.hex(theme.warning || '#FFFF00');
   if (score >= 50) return chalk.hex('#FFA500');
-  return chalk.red;
+  return chalk.hex(theme.error || '#FF0000');
 }
 
 export function scoreGrade(score: number): string {
@@ -36,7 +39,9 @@ export function scoreGrade(score: number): string {
 }
 
 export function check(ok: boolean, label: string): string {
-  return ok ? chalk.green(`  ✓ ${label}`) : chalk.red(`  ✗ ${label}`);
+  return ok 
+    ? chalk.hex(theme.success || '#00FF00')(`  ✓ ${label}`) 
+    : chalk.hex(theme.error || '#FF0000')(`  ✗ ${label}`);
 }
 
 export function timeAgo(dateStr: string): string {


### PR DESCRIPTION
## Description
Implements color theme configuration support as requested in #3.

## Changes
- Extended `config.ts` to support theme configuration with custom colors
- Added 5 built-in theme presets: default, minimal, dracula, monokai, solarized
- Updated `format.ts` to use theme colors via `chalk.hex()`
- Added `gpulse config` command to get/set configuration values
- Fallback to default colors if no config is set

## Features
### Built-in Presets
Users can activate presets with:
```bash
gpulse config theme dracula
gpulse config theme monokai
gpulse config theme solarized
gpulse config theme minimal
```

### Custom Colors
Users can also define custom colors in `~/.gpulse.json`:
```json
{
  "theme": {
    "header": "#FF6B6B",
    "subheader": "#4ECDC4",
    "success": "#2ECC71",
    "warning": "#F39C12",
    "error": "#E74C3C",
    "muted": "#95A5A6"
  }
}
```

### Config Command
```bash
gpulse config --list              # List all configuration
gpulse config theme               # Get current theme
gpulse config theme dracula       # Set theme preset
gpulse config defaultUser octocat # Set default user
```

## Testing
- Verified all theme presets work correctly
- Tested custom color configuration
- Confirmed fallback to default colors when no config exists
- Validated config command get/set operations

Fixes #3